### PR TITLE
callback with an error when no `bin` found, instead of crashing

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,10 @@ module.exports = function (name, opts, cb) {
     var binfield = pack.bin;
 
     var binpath = typeof binfield === 'object' ? binfield[executable] : binfield;
+    if (!binpath) {
+      cb(new Error("No bin `" + executable + "` in module `" + name + "`"));
+      return;
+    }
     var bin = path.join(dir, binpath);
     cb(null, bin);
   });

--- a/test/index.js
+++ b/test/index.js
@@ -41,11 +41,19 @@ test('\nno `executable` in options', function (t) {
   });
 })
 
-test('\nnon-existent', function (t) {
+test('\nnon-existent module', function (t) {
   resolveBin('non-existent', function (err, bin) {
     t.ok(err, 'returns error')
     t.equal(err.code, 'MODULE_NOT_FOUND', 'saying module not found')
     t.similar(err.message, /non-existent/, 'stating module name')
+    t.end()
+  });
+})
+
+test('\nnon-existent executable inside module', function (t) {
+  resolveBin('mocha', { executable: "no-such-bin" }, function (err, bin) {
+    t.ok(err, 'returns error')
+    t.similar(err.message, /no bin/i, 'stating module name')
     t.end()
   });
 })


### PR DESCRIPTION
Fixes a crash (exception: `Arguments to path.join must be strings`) when `package.json` has no `bin` field or when `bin` field does not contain the desired executable.
