### PR TITLE
resolve module from main paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,10 +4,11 @@ var findParentDir = require('find-parent-dir');
 var path = require('path');
 
 function requireResolve(name) {
+  const requireOpts = { paths: require.main.paths };
   try {
-    return require.resolve(name);
+    return require.resolve(name, requireOpts);
   } catch (err) {
-    const modJson = require.resolve(name+"/package.json");
+    const modJson = require.resolve(name+"/package.json", requireOpts);
     return path.dirname(modJson)
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Resolves the full path to the bin file of a given package by inspecting the \"bin\" field in its package.json.",
   "main": "index.js",
   "scripts": {
-    "test": "tap test/*.js"
+    "test": "tap test/{**/*,*}.test.js"
   },
   "repository": {
     "type": "git",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -3,7 +3,7 @@
 
 var test = require('tap').test
 var path = require('path')
-var resolveBin = require('../');
+var resolveBin = require('..');
 
 function relative(dir) {
   return path.relative(path.join(__dirname, '..'), dir)

--- a/test/nested/.gitignore
+++ b/test/nested/.gitignore
@@ -1,0 +1,1 @@
+!node_modules

--- a/test/nested/index.test.js
+++ b/test/nested/index.test.js
@@ -1,0 +1,37 @@
+'use strict';
+
+var test = require('tap').test;
+var path = require('path');
+var resolveBin = require('../..');
+
+function relative(dir) {
+  return path.relative(path.join(__dirname), dir);
+}
+
+test('\rtest-package (nested local)', function (t) {
+  resolveBin('test-package', function (err, bin) {
+    if (err) return t.fail(err);
+    t.equal(relative(bin), 'node_modules/test-package/bin.js');
+    t.end();
+  });
+});
+
+test('\ntest-package (nested local), sync', function (t) {
+  const bin = resolveBin.sync('test-package');
+  t.equal(relative(bin), 'node_modules/test-package/bin.js');
+  t.end();
+});
+
+test('\ntap (nested global)', function (t) {
+  resolveBin('tap', function (err, bin) {
+    if (err) return t.fail(err);
+    t.equal(relative(bin), '../../node_modules/tap/bin/tap.js');
+    t.end();
+  });
+});
+
+test('\ntap (nested global), sync', function (t) {
+  var bin = resolveBin.sync('tap');
+  t.equal(relative(bin), '../../node_modules/tap/bin/tap.js');
+  t.end();
+});

--- a/test/nested/node_modules/test-package/bin.js
+++ b/test/nested/node_modules/test-package/bin.js
@@ -1,0 +1,1 @@
+console.log('test-package');

--- a/test/nested/node_modules/test-package/package.json
+++ b/test/nested/node_modules/test-package/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "c",
+  "version": "no_version",
+  "bin": {
+    "test-package": "./bin.js"
+  }
+}

--- a/test/nested/package.json
+++ b/test/nested/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "nested-repository-test",
+  "dependencies": {
+    "test-package": "file:./node_modules/test"
+  }
+}


### PR DESCRIPTION
I found that when using this package within a monorepo, it could not find the package because it was hoisted and the package was not. e.g. it tried to resolve the package from the root node_module instead of the current package's. 

By overriding the paths for `require.resolve` it will start resolving from the program and not it's own node_modules