### PR TITLE
Replace Travis with GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Tests
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version:
+          - '0.8.x'
+          - '0.10.x'
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install
+    - run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,6 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - '0.8.x'
           - '0.10.x'
     steps:
     - uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: node_js
-node_js:
-  - "0.8"
-  - "0.10"
-before_install:
-  - npm install --upgrade npm -g

--- a/examples/dependency-cruiser.js
+++ b/examples/dependency-cruiser.js
@@ -25,7 +25,7 @@ resolveBin('dependency-cruiser', {executable:"depcruise"}, function (err, bin) {
 
 // => [..]/resolve-bin/node_modules/dependency-cruiser/bin/dependency-cruise.js
 
-const path = resolveBin.sync('dependency-cruiser', { executable: 'depcruise' });
+var path = resolveBin.sync('dependency-cruiser', { executable: 'depcruise' });
 console.log(path);
 
 // => [..]/resolve-bin/node_modules/dependency-cruiser/bin/dependency-cruise.js

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ function requireResolve(name) {
   try {
     return require.resolve(name);
   } catch (err) {
-    const modJson = require.resolve(name+"/package.json");
+    var modJson = require.resolve(name+"/package.json");
     return path.dirname(modJson)
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -80,7 +80,7 @@ test('\nopen-cli (without "main" field in package.json)', function (t) {
 })
 
 test('\nopen-cli (without "main" field in package.json), sync', function (t) {
-  const bin = resolveBin.sync('open-cli');
+  var bin = resolveBin.sync('open-cli');
   t.equal(relative(bin), 'node_modules/open-cli/cli.js')
   t.end()
 })
@@ -102,7 +102,7 @@ test('\ndependency-cruise (cannot import package.json)', function (t) {
 })
 
 test('\ndependency-cruise (cannot import package.json)', function (t) {
-  const bin = resolveBin.sync('dependency-cruiser');
+  var bin = resolveBin.sync('dependency-cruiser');
   t.equal(relative(bin), 'node_modules/dependency-cruiser/bin/dependency-cruise.js')
   t.end()
 })


### PR DESCRIPTION
Travis doesn't seem to be running and some code that wouldn't pass on the officially supported Node versions has gotten through (`const`).