### PR TITLE
require modern node versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - '0.10.x'
+          - '12.x'
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "url": "https://github.com/thlorenz/resolve-bin/blob/master/LICENSE"
   },
   "engine": {
-    "node": ">=0.6"
+    "node": ">= 12"
   }
 }


### PR DESCRIPTION
Tests for #10 are timing out on Node 0.10. I'm going to publish a patch version that reverts that and then cut 1.0 that requires 12+.