### PR TITLE
Update find-parent-dir dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "homepage": "https://github.com/thlorenz/resolve-bin",
   "dependencies": {
-    "find-parent-dir": "~0.3.0"
+    "find-parent-dir": "~0.3.1"
   },
   "devDependencies": {
     "dependency-cruiser": "^10.0.1",


### PR DESCRIPTION
Updating `find-parent-dir` dependency to the latest version which fixes a warning in node v16:

```
(node:96034) [DEP0128] DeprecationWarning: Invalid 'main' field in '/Users/chunter/workspace/stash/chunter/react-gibbon-next/node_modules/find-parent-dir/package.json' of 'find-parent-dir.js'. Please either fix that or report it to the module author
(Use `node --trace-deprecation ...` to show where the warning was created)
```