### PR TITLE
fix(esm): handle native ESM environment

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,9 @@ var findParentDir = require('find-parent-dir');
 var path = require('path');
 
 function requireResolve(name) {
-  var requireOpts = { paths: require.main.paths };
+  var requireOpts = {
+    paths: require.main ? require.main.paths : module.paths
+  };
   try {
     return require.resolve(name, requireOpts);
   } catch (err) {


### PR DESCRIPTION
In native ESM, require.main is undefined, but we can most likely get the same behavior with module.paths.

This makes a backward compatible change that is ESM-compatible.